### PR TITLE
Turn pyenv-mode into a local mode and introduce global-pyenv-mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,11 +12,14 @@ Integrate Fabián E. Gallina `python.el`_ with pyenv_ tool.  This allow
 packages which already use python.el (like python-django_) got pyenv
 virtual environments support out-of-the-box.
 
+Default automatic integration with `projectile`_ is available since 0.2.0.
+
 Pyenv mode does...
 ~~~~~~~~~~~~~~~~~~
 
 * Setup ``PYENV_VERSION`` environment variable and
-  ``python-shell-virtualenv-path`` custom variable based on user input
+  ``python-shell-virtualenv-path`` custom variable based on user input or
+  switching to a projectile project.
 
 Pyenv mode doesn't...
 ~~~~~~~~~~~~~~~~~~~~~
@@ -36,11 +39,29 @@ You can simply install package from Melpa_::
 Usage
 -----
 
-Add following block to your emacs configuration
-
 .. code:: lisp
 
     (pyenv-mode)
+
+This is enough to turn on ``pyenv-mode`` 's for all ``python-mode`` buffers. If
+you are using Projectile, switching to a Python project will setup its Pyenv
+Python version for you using either the project's ``.python-version`` file or
+the project's name.
+
+If you are not using Projectile, you will have to activate the appropriate
+Python version like the following while visiting a ``python`` mode buffer::
+
+    M-x pyenv-mode-set
+
+Advanced Usage
+--------------
+
+If you don't want to use the global ``pyenv-mode`` for whatever reason, you can
+still activate ``pyenv-mode``, but you have to use the local mode instead::
+
+.. code:: lisp
+
+    (add-hook 'python-mode-hook 'pyenv-local-mode)
 
 Now you are available to specify pyenv python version::
 
@@ -55,6 +76,17 @@ unset current version with::
 
     M-x pyenv-mode-unset
 
+FAQ
+---
+
+**Q:** My project has multiple ``.python-version`` files in different
+subdirectories, when I switch to a different subproject, ``pyenv-mode`` didn't
+switch to a different Python version for me, how come?
+**A:** By default Projectile only recognizes a couple types of projects by looking
+at specific version control system directories or common configuration files.
+You can either put an empty ``.projectile`` file in the directory or `register a
+new project type`_.
+
 Goodies
 -------
 
@@ -65,31 +97,11 @@ happens automatically
 * flycheck_ perform syntax checking according to python version you use
 * anaconda-mode_ search completions, definitions and references in chosen environment
 
-Projectile integration
-``````````````````````
-
-You can switch python version together with current project.  Drop
-following lines into emacs init file.  When use projectile switch
-project with ``C-c p p`` key binding ``pyenv-mode`` will activate
-environment matched project name.
-
-.. code:: lisp
-
-    (require 'pyenv-mode)
-
-    (defun projectile-pyenv-mode-set ()
-      "Set pyenv version matching project name."
-      (let ((project (projectile-project-name)))
-        (if (member project (pyenv-mode-versions))
-            (pyenv-mode-set project)
-          (pyenv-mode-unset))))
-
-    (add-hook 'projectile-after-switch-project-hook 'projectile-pyenv-mode-set)
-
-.. _python.el: http://repo.or.cz/w/emacs.git/blob_plain/master:/lisp/progmodes/python.el
+. _python.el: http://repo.or.cz/w/emacs.git/blob_plain/master:/lisp/progmodes/python.el
 .. _pyenv: https://github.com/yyuu/pyenv
 .. _python-django: https://github.com/fgallina/python-django.el
 .. _Melpa: https://melpa.org
 .. _flycheck: https://github.com/flycheck/flycheck
 .. _anaconda-mode: https://github.com/proofit404/anaconda-mode
 .. _projectile: https://github.com/bbatsov/projectile
+.. _register a new project type: http://projectile.readthedocs.io/en/latest/configuration/#adding-custom-project-types


### PR DESCRIPTION
Hi!

I've finally fixed this issue that's been bothering me for a while.

Currently, `pyenv-mode` is a global minor mode but not the conventional kind setup with `define-globalized-minor-mode`. It has a global keymap that clobbers `re-builder` but doesn't offer any help integrating with Projectile satisfactorily.

This PR turns the original `pyenv-mode` to `pyenv-local-mode`, the new `pyenv-mode` will now only turn on `pyenv-local-mode` and its associated keybindings only on `python` mode buffers.

In addition, the new global `pyenv-mode` will integrate with Projectile much more reliably than what's currently written on the README. In addition to trying to match the project name with a pyenv installed python version, it will first look at the project root and use the python version defined in the `.python-version` file instead.

I've taken care of not breaking backward compatibility in the PR. Ideally I'd like to only prefix all the variables and functions with `pyenv` instead of `pyenv-mode`, as per convention, but that's probably a bit too much cos I'll have to deprecate everything...

Hope you like this!